### PR TITLE
Added incentive (kill all enemies before proceed)

### DIFF
--- a/Levels/Actual Game Levels/level_1-1.tscn
+++ b/Levels/Actual Game Levels/level_1-1.tscn
@@ -9,7 +9,7 @@
 [sub_resource type="WorldBoundaryShape2D" id="WorldBoundaryShape2D_w48r1"]
 normal = Vector2(-1, 0)
 
-[node name="BaseLevel" instance=ExtResource("1_8add6")]
+[node name="Level1-1" instance=ExtResource("1_8add6")]
 
 [node name="ParallaxBackground" parent="." index="0" instance=ExtResource("2_fgliy")]
 
@@ -35,18 +35,16 @@ limit_right = 2342
 limit_bottom = 58
 editor_draw_limits = true
 
-[node name="Enemies" type="Node" parent="." index="5"]
-
-[node name="Gooey" parent="Enemies" index="0" instance=ExtResource("4_gngkw")]
+[node name="Gooey" parent="EnemyContainer" index="0" instance=ExtResource("4_gngkw")]
 position = Vector2(605, -44)
 
-[node name="Gooey2" parent="Enemies" index="1" instance=ExtResource("4_gngkw")]
+[node name="Gooey2" parent="EnemyContainer" index="1" instance=ExtResource("4_gngkw")]
 position = Vector2(1242, -44)
 
-[node name="Gooey3" parent="Enemies" index="2" instance=ExtResource("4_gngkw")]
+[node name="Gooey3" parent="EnemyContainer" index="2" instance=ExtResource("4_gngkw")]
 position = Vector2(1349, -43)
 
-[node name="Gooey4" parent="Enemies" index="3" instance=ExtResource("4_gngkw")]
+[node name="Gooey4" parent="EnemyContainer" index="3" instance=ExtResource("4_gngkw")]
 position = Vector2(2224, -156)
 
 [node name="ChangeLevelArea2D" parent="." index="6" instance=ExtResource("5_v5i6i")]

--- a/Levels/Actual Game Levels/level_1-2.tscn
+++ b/Levels/Actual Game Levels/level_1-2.tscn
@@ -10,7 +10,7 @@
 [sub_resource type="WorldBoundaryShape2D" id="WorldBoundaryShape2D_c6jul"]
 normal = Vector2(-1, 0)
 
-[node name="BaseLevel" instance=ExtResource("1_yy50q")]
+[node name="Level1-2" instance=ExtResource("1_yy50q")]
 
 [node name="ParallaxBackground" parent="." index="0" instance=ExtResource("2_43bon")]
 
@@ -36,21 +36,19 @@ limit_right = 2180
 limit_bottom = 54
 editor_draw_limits = true
 
-[node name="Enemies" type="Node" parent="." index="5"]
-
-[node name="Gooey" parent="Enemies" index="0" instance=ExtResource("4_8aevi")]
+[node name="Gooey" parent="EnemyContainer" index="0" instance=ExtResource("4_8aevi")]
 position = Vector2(432, -35)
 
-[node name="Gooey2" parent="Enemies" index="1" instance=ExtResource("4_8aevi")]
+[node name="Gooey2" parent="EnemyContainer" index="1" instance=ExtResource("4_8aevi")]
 position = Vector2(859, -370)
 
-[node name="Gooey3" parent="Enemies" index="2" instance=ExtResource("4_8aevi")]
+[node name="Gooey3" parent="EnemyContainer" index="2" instance=ExtResource("4_8aevi")]
 position = Vector2(1281, -34)
 
-[node name="Gooey4" parent="Enemies" index="3" instance=ExtResource("4_8aevi")]
+[node name="Gooey4" parent="EnemyContainer" index="3" instance=ExtResource("4_8aevi")]
 position = Vector2(208, -146)
 
-[node name="Golem" parent="Enemies" index="4" instance=ExtResource("5_yfmwg")]
+[node name="Golem" parent="EnemyContainer" index="4" instance=ExtResource("5_yfmwg")]
 position = Vector2(1849, -67)
 
 [node name="ChangeLevelArea2D" parent="." index="6" instance=ExtResource("6_5iosk")]

--- a/Levels/Actual Game Levels/level_1-3.tscn
+++ b/Levels/Actual Game Levels/level_1-3.tscn
@@ -10,7 +10,7 @@
 [sub_resource type="WorldBoundaryShape2D" id="WorldBoundaryShape2D_sfeyk"]
 normal = Vector2(-1, 0)
 
-[node name="BaseLevel" instance=ExtResource("1_7ofjt")]
+[node name="Level1-3" instance=ExtResource("1_7ofjt")]
 
 [node name="ParallaxBackground" parent="." index="0" instance=ExtResource("2_1ypfn")]
 
@@ -41,39 +41,37 @@ limit_right = 2040
 limit_bottom = 54
 editor_draw_limits = true
 
-[node name="Enemies" type="Node" parent="." index="6"]
-
-[node name="Gooey" parent="Enemies" index="0" instance=ExtResource("4_8cljg")]
+[node name="Gooey" parent="EnemyContainer" index="0" instance=ExtResource("4_8cljg")]
 position = Vector2(291, -162)
 
-[node name="Gooey2" parent="Enemies" index="1" instance=ExtResource("4_8cljg")]
+[node name="Gooey2" parent="EnemyContainer" index="1" instance=ExtResource("4_8cljg")]
 position = Vector2(565, -386)
 
-[node name="Gooey3" parent="Enemies" index="2" instance=ExtResource("4_8cljg")]
+[node name="Gooey3" parent="EnemyContainer" index="2" instance=ExtResource("4_8cljg")]
 position = Vector2(529, -386)
 
-[node name="Gooey4" parent="Enemies" index="3" instance=ExtResource("4_8cljg")]
+[node name="Gooey4" parent="EnemyContainer" index="3" instance=ExtResource("4_8cljg")]
 position = Vector2(1321, -291)
 
-[node name="Gooey5" parent="Enemies" index="4" instance=ExtResource("4_8cljg")]
+[node name="Gooey5" parent="EnemyContainer" index="4" instance=ExtResource("4_8cljg")]
 position = Vector2(1280, -291)
 
-[node name="Gooey6" parent="Enemies" index="5" instance=ExtResource("4_8cljg")]
+[node name="Gooey6" parent="EnemyContainer" index="5" instance=ExtResource("4_8cljg")]
 position = Vector2(1241, -291)
 
-[node name="Gooey7" parent="Enemies" index="6" instance=ExtResource("4_8cljg")]
+[node name="Gooey7" parent="EnemyContainer" index="6" instance=ExtResource("4_8cljg")]
 position = Vector2(544, -67)
 
-[node name="Gooey8" parent="Enemies" index="7" instance=ExtResource("4_8cljg")]
+[node name="Gooey8" parent="EnemyContainer" index="7" instance=ExtResource("4_8cljg")]
 position = Vector2(640, -36)
 
-[node name="Gooey9" parent="Enemies" index="8" instance=ExtResource("4_8cljg")]
+[node name="Gooey9" parent="EnemyContainer" index="8" instance=ExtResource("4_8cljg")]
 position = Vector2(1471, -274)
 
-[node name="Gooey10" parent="Enemies" index="9" instance=ExtResource("4_8cljg")]
+[node name="Gooey10" parent="EnemyContainer" index="9" instance=ExtResource("4_8cljg")]
 position = Vector2(1569, -274)
 
-[node name="Golem" parent="Enemies" index="10" instance=ExtResource("5_1ke5w")]
+[node name="Golem" parent="EnemyContainer" index="10" instance=ExtResource("5_1ke5w")]
 position = Vector2(1843, -71)
 
 [node name="ChangeLevelArea2D" parent="." index="7" instance=ExtResource("6_og6dt")]

--- a/Levels/Actual Game Levels/level_1-4.tscn
+++ b/Levels/Actual Game Levels/level_1-4.tscn
@@ -11,7 +11,7 @@
 [sub_resource type="WorldBoundaryShape2D" id="WorldBoundaryShape2D_82nr6"]
 normal = Vector2(-1, 0)
 
-[node name="BaseLevel" instance=ExtResource("1_53qao")]
+[node name="Level1-4" instance=ExtResource("1_53qao")]
 
 [node name="ParallaxBackground" parent="." index="0" instance=ExtResource("2_im8s7")]
 
@@ -37,30 +37,28 @@ limit_right = 2400
 limit_bottom = 54
 editor_draw_limits = true
 
-[node name="Enemies" type="Node" parent="." index="5"]
-
-[node name="Golem" parent="Enemies" index="0" instance=ExtResource("4_l7who")]
+[node name="Golem" parent="EnemyContainer" index="0" instance=ExtResource("4_l7who")]
 position = Vector2(2313, -164)
 
-[node name="Gooey" parent="Enemies" index="1" instance=ExtResource("5_r0plq")]
+[node name="Gooey" parent="EnemyContainer" index="1" instance=ExtResource("5_r0plq")]
 position = Vector2(2015, -115)
 
-[node name="Gooey2" parent="Enemies" index="2" instance=ExtResource("5_r0plq")]
+[node name="Gooey2" parent="EnemyContainer" index="2" instance=ExtResource("5_r0plq")]
 position = Vector2(1231, -49)
 
-[node name="Gooey3" parent="Enemies" index="3" instance=ExtResource("5_r0plq")]
+[node name="Gooey3" parent="EnemyContainer" index="3" instance=ExtResource("5_r0plq")]
 position = Vector2(627, -51)
 
-[node name="Gooey4" parent="Enemies" index="4" instance=ExtResource("5_r0plq")]
+[node name="Gooey4" parent="EnemyContainer" index="4" instance=ExtResource("5_r0plq")]
 position = Vector2(346, -34)
 
-[node name="Clawfly" parent="Enemies" index="5" instance=ExtResource("6_ghkxx")]
+[node name="Clawfly" parent="EnemyContainer" index="5" instance=ExtResource("6_ghkxx")]
 position = Vector2(989, -173)
 
-[node name="Clawfly2" parent="Enemies" index="6" instance=ExtResource("6_ghkxx")]
+[node name="Clawfly2" parent="EnemyContainer" index="6" instance=ExtResource("6_ghkxx")]
 position = Vector2(1309, -244)
 
-[node name="Clawfly3" parent="Enemies" index="7" instance=ExtResource("6_ghkxx")]
+[node name="Clawfly3" parent="EnemyContainer" index="7" instance=ExtResource("6_ghkxx")]
 position = Vector2(1706, -196)
 
 [node name="ChangeLevelArea2D" parent="." index="6" instance=ExtResource("7_ixld0")]

--- a/Levels/Actual Game Levels/level_1-5.tscn
+++ b/Levels/Actual Game Levels/level_1-5.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="PackedScene" uid="uid://b2vww2ct07iuh" path="res://Characters/Enemies/Gooey/gooey.tscn" id="4_c4f26"]
 [ext_resource type="PackedScene" uid="uid://5knv0m88jh0i" path="res://Characters/Enemies/Gooey/anti_gooey.tscn" id="5_ppxmw"]
 
-[node name="BaseLevel" instance=ExtResource("1_d1gcl")]
+[node name="Level1-5" instance=ExtResource("1_d1gcl")]
 
 [node name="ParallaxBackground" parent="." index="0" instance=ExtResource("2_misa4")]
 
@@ -36,69 +36,67 @@ limit_right = 2730
 limit_bottom = 54
 editor_draw_limits = true
 
-[node name="Enemies" type="Node" parent="." index="5"]
-
-[node name="Gooey4" parent="Enemies" index="0" instance=ExtResource("5_ppxmw")]
+[node name="Gooey4" parent="EnemyContainer" index="0" instance=ExtResource("5_ppxmw")]
 position = Vector2(1430, -35)
 
-[node name="Gooey3" parent="Enemies" index="1" instance=ExtResource("4_c4f26")]
+[node name="Gooey3" parent="EnemyContainer" index="1" instance=ExtResource("4_c4f26")]
 position = Vector2(1404, -35)
 
-[node name="Gooey" parent="Enemies" index="2" instance=ExtResource("4_c4f26")]
+[node name="Gooey" parent="EnemyContainer" index="2" instance=ExtResource("4_c4f26")]
 position = Vector2(687, -35)
 
-[node name="Gooey2" parent="Enemies" index="3" instance=ExtResource("5_ppxmw")]
+[node name="Gooey2" parent="EnemyContainer" index="3" instance=ExtResource("5_ppxmw")]
 position = Vector2(1020, -35)
 
-[node name="Gooey5" parent="Enemies" index="4" instance=ExtResource("4_c4f26")]
+[node name="Gooey5" parent="EnemyContainer" index="4" instance=ExtResource("4_c4f26")]
 position = Vector2(1818, -35)
 
-[node name="Gooey19" parent="Enemies" index="5" instance=ExtResource("4_c4f26")]
+[node name="Gooey19" parent="EnemyContainer" index="5" instance=ExtResource("4_c4f26")]
 position = Vector2(1719, -35)
 
-[node name="Gooey17" parent="Enemies" index="6" instance=ExtResource("4_c4f26")]
+[node name="Gooey17" parent="EnemyContainer" index="6" instance=ExtResource("4_c4f26")]
 position = Vector2(2014, -33)
 
-[node name="Gooey15" parent="Enemies" index="7" instance=ExtResource("4_c4f26")]
+[node name="Gooey15" parent="EnemyContainer" index="7" instance=ExtResource("4_c4f26")]
 position = Vector2(1979, -33)
 
-[node name="Gooey6" parent="Enemies" index="8" instance=ExtResource("4_c4f26")]
+[node name="Gooey6" parent="EnemyContainer" index="8" instance=ExtResource("4_c4f26")]
 position = Vector2(1849, -35)
 
-[node name="Gooey7" parent="Enemies" index="9" instance=ExtResource("5_ppxmw")]
+[node name="Gooey7" parent="EnemyContainer" index="9" instance=ExtResource("5_ppxmw")]
 position = Vector2(1833, -35)
 
-[node name="Gooey20" parent="Enemies" index="10" instance=ExtResource("5_ppxmw")]
+[node name="Gooey20" parent="EnemyContainer" index="10" instance=ExtResource("5_ppxmw")]
 position = Vector2(1748, -35)
 
-[node name="Gooey18" parent="Enemies" index="11" instance=ExtResource("5_ppxmw")]
+[node name="Gooey18" parent="EnemyContainer" index="11" instance=ExtResource("5_ppxmw")]
 position = Vector2(2029, -33)
 
-[node name="Gooey16" parent="Enemies" index="12" instance=ExtResource("5_ppxmw")]
+[node name="Gooey16" parent="EnemyContainer" index="12" instance=ExtResource("5_ppxmw")]
 position = Vector2(1996, -33)
 
-[node name="Gooey8" parent="Enemies" index="13" instance=ExtResource("5_ppxmw")]
+[node name="Gooey8" parent="EnemyContainer" index="13" instance=ExtResource("5_ppxmw")]
 position = Vector2(1866, -36)
 
-[node name="Gooey9" parent="Enemies" index="14" instance=ExtResource("4_c4f26")]
+[node name="Gooey9" parent="EnemyContainer" index="14" instance=ExtResource("4_c4f26")]
 position = Vector2(1884, -34)
 
-[node name="Gooey10" parent="Enemies" index="15" instance=ExtResource("5_ppxmw")]
+[node name="Gooey10" parent="EnemyContainer" index="15" instance=ExtResource("5_ppxmw")]
 position = Vector2(1899, -34)
 
-[node name="Gooey11" parent="Enemies" index="16" instance=ExtResource("4_c4f26")]
+[node name="Gooey11" parent="EnemyContainer" index="16" instance=ExtResource("4_c4f26")]
 position = Vector2(1912, -34)
 
-[node name="Gooey12" parent="Enemies" index="17" instance=ExtResource("5_ppxmw")]
+[node name="Gooey12" parent="EnemyContainer" index="17" instance=ExtResource("5_ppxmw")]
 position = Vector2(1927, -34)
 
-[node name="Gooey13" parent="Enemies" index="18" instance=ExtResource("4_c4f26")]
+[node name="Gooey13" parent="EnemyContainer" index="18" instance=ExtResource("4_c4f26")]
 position = Vector2(1944, -34)
 
-[node name="Gooey14" parent="Enemies" index="19" instance=ExtResource("5_ppxmw")]
+[node name="Gooey14" parent="EnemyContainer" index="19" instance=ExtResource("5_ppxmw")]
 position = Vector2(1961, -33)
 
-[node name="Label" type="Label" parent="." index="7"]
+[node name="Label" type="Label" parent="." index="6"]
 offset_left = 2398.0
 offset_top = -235.0
 offset_right = 2674.0

--- a/Levels/base_level.tscn
+++ b/Levels/base_level.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=14 format=3 uid="uid://cnb1q5qwbielt"]
+[gd_scene load_steps=15 format=3 uid="uid://cnb1q5qwbielt"]
 
 [ext_resource type="Texture2D" uid="uid://b3sn3twsvajog" path="res://Art/Assets/Cyberpunk City Tileset/Assets/Tiles.png" id="1_smwv0"]
 [ext_resource type="Texture2D" uid="uid://dxpsuhf1sao1t" path="res://Art/Assets/Cyberpunk City Tileset/Assets/Props-01.png" id="2_u0vgo"]
@@ -7,6 +7,7 @@
 [ext_resource type="PackedScene" uid="uid://bd06xtnb3u2f2" path="res://Characters/Player/player.tscn" id="4_qf7cn"]
 [ext_resource type="Texture2D" uid="uid://dq276wnx1cm3y" path="res://Art/Assets/AbandonedCity Tileset/FullTileset.png" id="5_pgqao"]
 [ext_resource type="PackedScene" uid="uid://biu8yengrvq78" path="res://UI/hud.tscn" id="6_iclmu"]
+[ext_resource type="Script" path="res://Levels/enemy_container.gd" id="7_2vbjv"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_ps833"]
 texture = ExtResource("1_smwv0")
@@ -2336,5 +2337,8 @@ position_smoothing_enabled = true
 drag_horizontal_enabled = true
 drag_vertical_enabled = true
 drag_vertical_offset = -0.5
+
+[node name="EnemyContainer" type="Node" parent="."]
+script = ExtResource("7_2vbjv")
 
 [node name="HUD" parent="." instance=ExtResource("6_iclmu")]

--- a/Levels/change_level_area_2d.gd
+++ b/Levels/change_level_area_2d.gd
@@ -2,6 +2,13 @@ extends Area2D
 
 @export var new_level_name: String
 
+func _ready() -> void:
+	monitoring = false
+	SceneManager.enemies_cleared.connect(on_enemies_cleared)
+
 # because of collision mask, no need to explicitly check for player
 func _on_body_entered(body: Node2D) -> void:
 	SceneManager.transition_to_scene(new_level_name)
+
+func on_enemies_cleared() -> void:
+	monitoring = true

--- a/Levels/change_level_area_2d.tscn
+++ b/Levels/change_level_area_2d.tscn
@@ -5,6 +5,7 @@
 [node name="ChangeLevelArea2D" type="Area2D"]
 collision_layer = 64
 collision_mask = 18
+monitoring = false
 script = ExtResource("1_cagbq")
 
 [connection signal="body_entered" from="." to="." method="_on_body_entered"]

--- a/Levels/enemy_container.gd
+++ b/Levels/enemy_container.gd
@@ -1,0 +1,7 @@
+class_name EnemyContainer
+extends Node
+
+func _process(delta: float) -> void:
+	if get_children().is_empty():
+		SceneManager.all_enemies_died()
+		queue_free()

--- a/Levels/enemy_container.tscn
+++ b/Levels/enemy_container.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://c8a1pitv018ht"]
+
+[ext_resource type="Script" path="res://Levels/enemy_container.gd" id="1_jtdlv"]
+
+[node name="EnemyContainer" type="Node"]
+script = ExtResource("1_jtdlv")

--- a/Managers/scene_manager.gd
+++ b/Managers/scene_manager.gd
@@ -1,5 +1,7 @@
 extends Node
 
+signal enemies_cleared()
+
 var scenes: Dictionary = {
 	"Level1": "res://Levels/level_1.tscn",
 	"TestLevel1": "res://Levels/Test Level/test_level.tscn",
@@ -22,3 +24,6 @@ func transition_to_scene(scene_name: String) -> void:
 	var err: int = get_tree().change_scene_to_file(scene_path)
 	if not err == OK:
 		print("Error: Unable to change scene")
+
+func all_enemies_died() -> void:
+	enemies_cleared.emit()


### PR DESCRIPTION
Added a signal to SceneManager that can emit when all enemies are dead.

This signal is emited using the all_enemies_died() function, which is called within the new EnemyContainer, when all the enemies die.

The changelevelarea2d connects to the signal on spawn, and if there are no enemies, then monitoring will turn on. Monitoring is off by default